### PR TITLE
Fix small typo error 

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -47,7 +47,7 @@ module.exports = {
     if (!config.web.middlewares.addMethods) {
       config.web.middlewares.addMethods = (req, res, next) => {
         req.log = app.log
-        req.wantsJSON = /application\/json;/.test(req.get('accept'))
+        req.wantsJSON = /application\/json/.test(req.get('accept'))
         res.serverError = config.web.middlewares['500']
         res.notFound = config.web.middlewares['404']
 


### PR DESCRIPTION

Usually ajax libraries send header like that, without semicolon at the end

`{ "Accept" : "application/json"}`